### PR TITLE
fixing check private key is encrypted for openssh keys

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ func getVersion() semver.Version {
 	return semver.Version{
 		Major: 0,
 		Minor: 1,
-		Patch: 1,
+		Patch: 2,
 		Pre: []semver.PRVersion{
 			{VersionStr: "git"},
 		},


### PR DESCRIPTION
if ssh.PassphraseMissingError on unencrypted ssh-key - try to parse it as encrypted